### PR TITLE
Remove default "any" to avoid issues

### DIFF
--- a/plugins/modules/panos_security_rule.py
+++ b/plugins/modules/panos_security_rule.py
@@ -398,20 +398,20 @@ def main():
         sdk_params=dict(
             rule_name=dict(required=True, sdk_param="name"),
             source_zone=dict(
-                type="list", elements="str", default=["any"], sdk_param="fromzone"
+                type="list", elements="str", default=[], sdk_param="fromzone"
             ),
             source_ip=dict(
-                type="list", elements="str", default=["any"], sdk_param="source"
+                type="list", elements="str", default=[], sdk_param="source"
             ),
             source_user=dict(type="list", elements="str", default=["any"]),
             hip_profiles=dict(type="list", elements="str"),
             destination_zone=dict(
-                type="list", elements="str", default=["any"], sdk_param="tozone"
+                type="list", elements="str", default=[], sdk_param="tozone"
             ),
             destination_ip=dict(
-                type="list", elements="str", default=["any"], sdk_param="destination"
+                type="list", elements="str", default=[], sdk_param="destination"
             ),
-            application=dict(type="list", elements="str", default=["any"]),
+            application=dict(type="list", elements="str", default=[]),
             service=dict(type="list", elements="str", default=["application-default"]),
             category=dict(type="list", elements="str", default=["any"]),
             action=dict(


### PR DESCRIPTION
Default values of Application, Source/Destination Zone and IP addresses are set to "any".
When adding a new rule, we do specify the zones and IP addresses, so default value is nullified.
However, when editing an existing rule, the "any" is added over the existing rule, resulting in total purpose of that specific rule. So removing these "any" default values from the security rule can save extra effort and errors/issues.